### PR TITLE
Add comprehensive unit tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3660,6 +3660,7 @@ dependencies = [
  "rayon",
  "resolve-path",
  "serde",
+ "tempfile",
  "toml",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,9 @@ name = "wallity"
 version = "0.1.0"
 edition = "2024"
 
+[dev-dependencies]
+tempfile = "3.17.1"
+
 [dependencies]
 anyhow = "1.0.100"
 image = "0.25.9"

--- a/src/config.rs
+++ b/src/config.rs
@@ -106,4 +106,31 @@ mod tests {
         assert!(config.wallpaper_path.is_some());
         assert_eq!(config.post_script, Some("test".to_string()));
     }
+
+    #[test]
+    fn test_merge_all_fields() {
+        let mut config = AppConfig::empty();
+        let other = AppConfig {
+            wallpaper_path: Some(PathBuf::from("/wallpapers")),
+            current_wallpaper: Some(PathBuf::from("/current")),
+            post_script: Some("script".to_string()),
+            cache_path: Some(PathBuf::from("/cache")),
+        };
+        config = config.merge(other);
+        assert!(config.wallpaper_path.is_some());
+        assert!(config.current_wallpaper.is_some());
+        assert_eq!(config.post_script, Some("script".to_string()));
+        assert!(config.cache_path.is_some());
+    }
+
+    #[test]
+    fn test_merge_none() {
+        let original = AppConfig::default();
+        let merged = original.clone().merge(AppConfig::empty());
+
+        assert_eq!(original.wallpaper_path, merged.wallpaper_path);
+        assert_eq!(original.current_wallpaper, merged.current_wallpaper);
+        assert_eq!(original.post_script, merged.post_script);
+        assert_eq!(original.cache_path, merged.cache_path);
+    }
 }

--- a/src/thumbnail.rs
+++ b/src/thumbnail.rs
@@ -20,14 +20,66 @@ pub fn list_thumbnails() -> HashSet<String> {
         return HashSet::new();
     };
 
+    list_thumbnails_from_path(path)
+}
+
+fn list_thumbnails_from_path(path: &Path) -> HashSet<String> {
     let Ok(dir) = fs::read_dir(path) else {
         return HashSet::new();
     };
 
     dir.filter_map(|entry| {
-        entry
-            .ok()
-            .and_then(|v| v.path().file_stem().map(|s| s.to_string_lossy().to_string()))
+        let entry = entry.ok()?;
+        let path = entry.path();
+
+        if path.extension().and_then(|e| e.to_str())? == "jpeg" {
+            path.file_stem().map(|s| s.to_string_lossy().to_string())
+        } else {
+            None
+        }
     })
     .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+    use std::fs::File;
+    use image::{RgbImage, ImageFormat};
+
+    #[test]
+    fn test_gen_thumbnail() {
+        let dir = tempdir().unwrap();
+        let input_path = dir.path().join("input.png");
+        let output_path = dir.path().join("output.jpeg");
+
+        // Create a dummy image
+        let img = RgbImage::new(100, 100);
+        img.save_with_format(&input_path, ImageFormat::Png).unwrap();
+
+        let result = gen_thumbnail(&input_path, &output_path);
+        assert!(result.is_ok());
+        assert!(output_path.exists());
+
+        // Verify it's a valid image
+        let thumb = image::open(&output_path).unwrap();
+        // 100x100 image scaled to fit 320x150 should be 150x150
+        assert_eq!(thumb.width(), 150);
+        assert_eq!(thumb.height(), 150);
+    }
+
+    #[test]
+    fn test_list_thumbnails_from_path() {
+        let dir = tempdir().unwrap();
+        File::create(dir.path().join("thumb1.jpeg")).unwrap();
+        File::create(dir.path().join("thumb2.jpeg")).unwrap();
+        File::create(dir.path().join("not_a_thumb.txt")).unwrap();
+
+        let thumbnails = list_thumbnails_from_path(dir.path());
+        assert_eq!(thumbnails.len(), 2);
+        assert!(thumbnails.contains("thumb1"));
+        assert!(thumbnails.contains("thumb2"));
+        assert!(!thumbnails.contains("not_a_thumb"));
+    }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -354,3 +354,118 @@ impl AppView {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::image::WallpaperImage;
+    use crate::message::Message;
+    use iced::keyboard::key::Named;
+    use std::path::PathBuf;
+
+    fn create_dummy_image(name: &str) -> WallpaperImage {
+        WallpaperImage {
+            name: name.to_string(),
+            img_path: PathBuf::from(name),
+            thumbnail_path: PathBuf::from(name),
+            thumbnail_handle: None,
+            is_visible: false,
+            is_loading: false,
+        }
+    }
+
+    #[test]
+    fn test_app_view_new() {
+        let view = AppView::new();
+        assert!(view.images.is_empty());
+        assert_eq!(view.selected_idx, 0);
+        assert_eq!(view.visible_range, (0, 20));
+    }
+
+    #[test]
+    fn test_app_view_update_discovered() {
+        let mut view = AppView::new();
+        let image = create_dummy_image("test.jpg");
+
+        let _ = view.update(Message::WallpaperDiscovered(image));
+        assert_eq!(view.images.len(), 1);
+        assert_eq!(view.images[0].name, "test.jpg");
+    }
+
+    #[test]
+    fn test_app_view_update_hover() {
+        let mut view = AppView::new();
+        view.images.push(create_dummy_image("1"));
+        view.images.push(create_dummy_image("2"));
+
+        let _ = view.update(Message::ImageHovered(Some(1)));
+        assert_eq!(view.selected_idx, 1);
+
+        let _ = view.update(Message::ImageHovered(None));
+        assert_eq!(view.selected_idx, 1);
+    }
+
+    #[test]
+    fn test_app_view_update_key_navigation() {
+        let mut view = AppView::new();
+        for i in 0..10 {
+            view.images.push(create_dummy_image(&i.to_string()));
+        }
+
+        // Down
+        let _ = view.update(Message::KeyPressed(key::Key::Named(Named::ArrowDown)));
+        assert_eq!(view.selected_idx, IMAGES_PER_ROW);
+
+        // Right
+        let _ = view.update(Message::KeyPressed(key::Key::Named(Named::ArrowRight)));
+        assert_eq!(view.selected_idx, IMAGES_PER_ROW + 1);
+
+        // Up
+        let _ = view.update(Message::KeyPressed(key::Key::Named(Named::ArrowUp)));
+        assert_eq!(view.selected_idx, 1);
+
+        // Left
+        let _ = view.update(Message::KeyPressed(key::Key::Named(Named::ArrowLeft)));
+        assert_eq!(view.selected_idx, 0);
+
+        // Left at 0
+        let _ = view.update(Message::KeyPressed(key::Key::Named(Named::ArrowLeft)));
+        assert_eq!(view.selected_idx, 0);
+    }
+
+    #[test]
+    fn test_app_view_update_key_navigation_edge_cases() {
+        let mut view = AppView::new();
+        for i in 0..2 {
+            view.images.push(create_dummy_image(&i.to_string()));
+        }
+
+        // ArrowDown at row 0 with only 2 images (IMAGES_PER_ROW is 4)
+        // target_idx = 0 + 4 = 4. 4 >= 2, so selected_idx = 2 - 1 = 1.
+        let _ = view.update(Message::KeyPressed(key::Key::Named(Named::ArrowDown)));
+        assert_eq!(view.selected_idx, 1);
+
+        // ArrowRight at the end
+        let _ = view.update(Message::KeyPressed(key::Key::Named(Named::ArrowRight)));
+        assert_eq!(view.selected_idx, 1);
+
+        // Enter
+        let _ = view.update(Message::KeyPressed(key::Key::Named(Named::Enter)));
+        // Should just return a task, no state change here
+        assert_eq!(view.selected_idx, 1);
+    }
+
+    #[test]
+    fn test_app_view_update_thumbnail_loaded() {
+        let mut view = AppView::new();
+        view.images.push(create_dummy_image("1"));
+
+        let handle = iced_image::Handle::from_rgba(1, 1, vec![0, 0, 0, 0]);
+        let _ = view.update(Message::ThumbnailLoaded(0, handle));
+
+        assert!(view.images[0].thumbnail_handle.is_some());
+        assert!(view.images[0].is_visible);
+        assert!(!view.images[0].is_loading);
+    }
+
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -29,3 +29,54 @@ pub fn resolve_dir_path(path: &str) -> Result<PathBuf> {
 
     Ok(resolved)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_get_absolute_path() {
+        // Test with a regular relative path
+        let path = "src/main.rs";
+        let resolved = get_absolute_path(path).unwrap();
+        assert!(resolved.is_absolute());
+        assert!(resolved.ends_with("src/main.rs"));
+
+        // Test with tilde
+        let tilde_path = "~/some_file";
+        let resolved = get_absolute_path(tilde_path).unwrap();
+        assert!(resolved.is_absolute());
+        // We don't necessarily know the exact home dir, but it should be absolute and contain "some_file"
+        assert!(resolved.to_string_lossy().contains("some_file"));
+    }
+
+    #[test]
+    fn test_resolve_file_path() {
+        let dir = tempdir().unwrap();
+        let sub_dir = dir.path().join("sub/dir");
+        let file_path = sub_dir.join("test.txt");
+        let file_path_str = file_path.to_string_lossy();
+
+        assert!(!sub_dir.exists());
+
+        let resolved = resolve_file_path(&file_path_str).unwrap();
+        assert_eq!(resolved, file_path);
+        assert!(sub_dir.exists());
+        assert!(sub_dir.is_dir());
+    }
+
+    #[test]
+    fn test_resolve_dir_path() {
+        let dir = tempdir().unwrap();
+        let new_dir = dir.path().join("new_dir");
+        let new_dir_str = new_dir.to_string_lossy();
+
+        assert!(!new_dir.exists());
+
+        let resolved = resolve_dir_path(&new_dir_str).unwrap();
+        assert_eq!(resolved, new_dir);
+        assert!(new_dir.exists());
+        assert!(new_dir.is_dir());
+    }
+}

--- a/src/wallpaper.rs
+++ b/src/wallpaper.rs
@@ -125,3 +125,24 @@ pub fn load_wallpapers(tx: mpsc::SyncSender<WallpaperImage>) -> Result<(), Strin
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn test_is_supported_extension() {
+        assert!(is_supported_extension(Path::new("test.png")));
+        assert!(is_supported_extension(Path::new("test.jpg")));
+        assert!(is_supported_extension(Path::new("test.jpeg")));
+        assert!(is_supported_extension(Path::new("test.webp")));
+
+        assert!(is_supported_extension(Path::new("test.PNG")));
+        assert!(is_supported_extension(Path::new("test.JPG")));
+
+        assert!(!is_supported_extension(Path::new("test.txt")));
+        assert!(!is_supported_extension(Path::new("test.gif")));
+        assert!(!is_supported_extension(Path::new("test")));
+    }
+}


### PR DESCRIPTION
Added a comprehensive suite of unit tests to the Wallity codebase, covering configuration, UI state management, thumbnail generation, and utility functions. Refactored some logic to be more testable and fixed a minor bug in thumbnail listing. Added `tempfile` for reliable test environments.

---
*PR created automatically by Jules for task [13941640383883398843](https://jules.google.com/task/13941640383883398843) started by @asce4s*