### PR TITLE
Add initial packaging files for wallity-git

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,0 +1,17 @@
+pkgbase = wallity-git
+	pkgdesc = A desktop wallpaper manager built with Rust and Iced for Wayland/Hyprland
+	pkgver = r1.0000000
+	pkgrel = 1
+	url = https://github.com/asce4s/wallity-iced
+	arch = x86_64
+	license = MIT
+	makedepends = cargo
+	makedepends = git
+	depends = wayland
+	depends = gcc-libs
+	provides = wallity
+	conflicts = wallity
+	source = wallity-git::git+https://github.com/asce4s/wallity-iced.git
+	sha256sums = SKIP
+
+pkgname = wallity-git

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,45 @@
+# Maintainer: Your Name <your@email.com>
+pkgname=wallity-git
+pkgver=r20.08008c6
+pkgrel=1
+pkgdesc="A desktop wallpaper manager built with Rust and Iced for Wayland/Hyprland"
+arch=('x86_64')
+url="https://github.com/asce4s/wallity-iced"
+license=('MIT')
+depends=('wayland' 'gcc-libs')
+makedepends=('cargo' 'git')
+provides=('wallity')
+conflicts=('wallity')
+source=("${pkgname}::git+https://github.com/asce4s/wallity-iced.git")
+sha256sums=('SKIP')
+
+pkgver() {
+    cd "${pkgname}"
+    printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
+
+prepare() {
+    cd "${pkgname}"
+    export RUSTUP_TOOLCHAIN=stable
+    cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+}
+
+build() {
+    cd "${pkgname}"
+    export RUSTUP_TOOLCHAIN=stable
+    export CARGO_TARGET_DIR=target
+    cargo build --frozen --release
+}
+
+check() {
+    cd "${pkgname}"
+    export RUSTUP_TOOLCHAIN=stable
+    cargo test --frozen --release
+}
+
+package() {
+    cd "${pkgname}"
+    install -Dm0755 -t "${pkgdir}/usr/bin/" "target/release/wallity"
+    install -Dm0644 -t "${pkgdir}/usr/share/licenses/${pkgname}/" LICENSE
+    install -Dm0644 -t "${pkgdir}/usr/share/doc/${pkgname}/" README.md
+}

--- a/README.md
+++ b/README.md
@@ -35,6 +35,23 @@ This application is specifically designed for:
 
 ## Installation
 
+### AUR (Arch Linux)
+
+Install the latest git version using your preferred AUR helper:
+
+```bash
+# Using paru
+paru -S wallity-git
+
+# Using yay
+yay -S wallity-git
+
+# Manually with makepkg
+git clone https://aur.archlinux.org/wallity-git.git
+cd wallity-git
+makepkg -si
+```
+
 ### From Source
 
 1. Clone the repository:


### PR DESCRIPTION
- Create .SRCINFO and PKGBUILD for the wallity-git package.
- Update README.md with installation instructions for AUR.
- Ensure dependencies and build steps are defined for Rust and Wayland integration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Arch Linux AUR installation guide covering multiple installation methods: paru, yay package helpers, and manual makepkg-based builds.

* **Chores**
  * Added Arch Linux packaging support including build scripts, package metadata, and configuration files for AUR distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->